### PR TITLE
set hostname for the machine and update the README

### DIFF
--- a/12.5/Vagrantfile
+++ b/12.5/Vagrantfile
@@ -4,7 +4,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "plesk/plesk-12.5"
+  config.vm.box      = "plesk/plesk-12.5"
+  config.vm.hostname = "plesk-12.5.vagrant.vm"
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 1024

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ If you want to build an image from scratch, Vagrantfile.dev can be used:
 
 # Access
 
-Login URL: [http://localhost:8880](http://localhost:8880)
+Login URL: [https://localhost:8880](https://localhost:8880)
 
 Credentials: admin / changeme


### PR DESCRIPTION
The readme uses http instead of https for localhost, this results in
a redirect to the hostname; packer-virtualbox-iso-1422588891 but that does't
exist. So set a more logical hostname and correct the readme link.

Using something like https://github.com/cogitatio/vagrant-hostsupdater makes it work on the fly. :)
